### PR TITLE
Add warnings for additional unsupported Connect modules

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,12 +49,29 @@ program
 const { url, type, output } = program.opts();
 
 const UNSUPPORTED_MODULES = new Set([
+  "automationActions",
   "jiraBuildInfoProvider",
   "jiraDeploymentInfoProvider",
   "jiraDevelopmentTool",
   "jiraFeatureFlagInfoProvider",
   "jiraRemoteLinkInfoProvider",
   "jiraSecurityInfoProvider",
+  "serviceDeskOrganizationActions",
+  "serviceDeskOrganizationPanels",
+  "serviceDeskPortalFooters",
+  "serviceDeskPortalHeaders",
+  "serviceDeskPortalProfileActions",
+  "serviceDeskPortalProfilePanels",
+  "serviceDeskPortalRequestCreatePropertyPanels",
+  "serviceDeskPortalRequestViewActions",
+  "serviceDeskPortalRequestViewDetailsPanels",
+  "serviceDeskPortalRequestViewPanels",
+  "serviceDeskPortalSubHeaders",
+  "serviceDeskPortalUserMenuActions",
+  "serviceDeskQueueGroups",
+  "serviceDeskQueues",
+  "serviceDeskReportGroups",
+  "serviceDeskReports"
 ]);
 
 // Helper function to download Atlassian Connect descriptor


### PR DESCRIPTION
https://ecosystem.atlassian.net/jira/software/c/projects/FRGE/issues/FRGE-1348

These additional Connect modules are not currently supported in Forge apps, so displaying a warning in the connect-to-forge tool for now until they are supported.