### PR TITLE
Add `repository` field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
   },
   "author": "Robert Massaioli <connect-on-forge@rmdir.app>",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/robertmassaioli/connect-to-forge.git"
+  },
   "files": [
     "dist/**/*",
     "README.md"


### PR DESCRIPTION
This is useful when trying to find the source code for an npm package