### PR TITLE
Remove all modules from unsupported list since they are all supported

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,31 +48,7 @@ program
 
 const { url, type, output } = program.opts();
 
-const UNSUPPORTED_MODULES = new Set([
-  "automationActions",
-  "jiraBuildInfoProvider",
-  "jiraDeploymentInfoProvider",
-  "jiraDevelopmentTool",
-  "jiraFeatureFlagInfoProvider",
-  "jiraRemoteLinkInfoProvider",
-  "jiraSecurityInfoProvider",
-  "serviceDeskOrganizationActions",
-  "serviceDeskOrganizationPanels",
-  "serviceDeskPortalFooters",
-  "serviceDeskPortalHeaders",
-  "serviceDeskPortalProfileActions",
-  "serviceDeskPortalProfilePanels",
-  "serviceDeskPortalRequestCreatePropertyPanels",
-  "serviceDeskPortalRequestViewActions",
-  "serviceDeskPortalRequestViewDetailsPanels",
-  "serviceDeskPortalRequestViewPanels",
-  "serviceDeskPortalSubHeaders",
-  "serviceDeskPortalUserMenuActions",
-  "serviceDeskQueueGroups",
-  "serviceDeskQueues",
-  "serviceDeskReportGroups",
-  "serviceDeskReports"
-]);
+const UNSUPPORTED_MODULES = new Set([]);
 
 // Helper function to download Atlassian Connect descriptor
 async function downloadConnectDescriptor(url: string): Promise<ConnectDescriptor> {


### PR DESCRIPTION
- Remove all supported modules (all of them) from the unsupported modules list
- Kept the `UNSUPPORTED_MODULES` variable + logic in case we ever need to add modules to this list in the future