### PR TITLE
Include required app.runtime.name in Forge manifest

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,9 @@ interface ForgeManifest {
       authentication?: string;
       remote: string;
     };
+    runtime: {
+      name: string;
+    };
     licensing?: {
       enabled: boolean
     };
@@ -86,6 +89,9 @@ function genDefaultManifest(connect: ConnectDescriptor): ForgeManifest {
       connect: {
         key: connect.key,
         remote: 'connect'
+      },
+      runtime: {
+        name: 'nodejs18.x'
       }
     },
     remotes: [


### PR DESCRIPTION
`app.runtime.name` in the Forge manifest is now a required field - see https://developer.atlassian.com/platform/forge/changelog/#CHANGE-1634