### PR TITLE
Fix translations key

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -143,7 +143,7 @@ function convertToForgemanifest(manifest: ForgeManifest, connect: ConnectDescrip
     const moduleName = `${type}:translations`;
     manifest.connectModules[moduleName] = [{
       paths: connect.translations.paths,
-      key: moduleName,
+      key: 'connect-translations',
     }];
     console.log(` - Moved translations into connectModules.${moduleName}.`);
   }


### PR DESCRIPTION
The key currently used (`${type}:translations`) includes `:` which will be rejected by Forge