### PR TITLE
ONECLOUD-11582 Automate the migration of a Jira Global Permission module and a Jira Project Permission module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-to-forge",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "Converts an Atlassian Connect Descritor to a connect-on-forge manifest.",
   "main": "dist/index",
   "bin": {


### PR DESCRIPTION
Automate the migration of a Jira Global Permission module and a Jira Project Permission module.
This change has been tested E2E on staging Jira.